### PR TITLE
Fix WHO_AM_I read & refactor i2c calls

### DIFF
--- a/mpl3115a2.cpp
+++ b/mpl3115a2.cpp
@@ -1,9 +1,11 @@
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdint.h>
 #include <stdexcept>
 #include <string>
 #include <string.h>
+#include <vector>
 
 #include <errno.h>
 #include <fcntl.h>
@@ -14,15 +16,17 @@
 #include "mpl3115a2.hpp"
 
 
+// Register addresses
 constexpr uint8_t MPL3115A2_ADDRESS = 0x60;
 constexpr uint8_t STATUS = 0x00;
 constexpr uint8_t DATA_READY = 0x06;
 constexpr uint8_t WHO_AM_I = 0x0C;
-constexpr uint8_t DEVICE_ID = 0xC4;
 constexpr uint8_t PT_DATA_CFG = 0x13;
+// Register defaults
+constexpr uint8_t DEVICE_ID = 0xC4;
 
 
-MPL3115A2::MPL3115A2(unsigned int adapterNumber)
+MPL3115A2::MPL3115A2(const unsigned int adapterNumber)
 {
     std::ostringstream oss;
     oss << "/dev/i2c-" << adapterNumber;
@@ -42,19 +46,12 @@ MPL3115A2::MPL3115A2(unsigned int adapterNumber)
     }
 
     // Confirm that the device at this address is indeed the MPL3115A2
-    uint8_t buf[1];
-    buf[0] = WHO_AM_I;
-    if (read(m_i2cFile, buf, 1) != 1)
-    {
-        std::ostringstream err;
-        err << "Could not read WHO_AM_I register" << strerror(errno);
-        throw std::runtime_error(err.str());
-    }
-    if (buf[0] != DEVICE_ID)
+    std::vector<uint8_t> whoIsThis = readBytes(WHO_AM_I, 1);
+    if (whoIsThis[0] != DEVICE_ID)
     {
         std::ostringstream err;
         err << "WHO_AM_I register contained: " << std::hex
-            << static_cast<int>(buf[0]) << std::endl
+            << whoIsThis[0] << std::endl
             << "Expected: " << std::hex << DEVICE_ID << std::endl;
         throw std::runtime_error(err.str());
     }
@@ -62,5 +59,40 @@ MPL3115A2::MPL3115A2(unsigned int adapterNumber)
     {
         std::cout << "MPL3115A2 confirmed to be on I2C bus represented by "
                   << m_i2cFilename << std::endl;
+    }
+}
+
+
+std::vector<uint8_t> MPL3115A2::readBytes(const uint8_t reg, const unsigned int size) const
+{
+    std::vector<uint8_t> regVector {reg};
+    writeBytes(regVector);  // Tell slave where the data we want is
+    std::unique_ptr<uint8_t> cArray(new uint8_t[size]);
+    if (read(m_i2cFile, cArray.get(), 1) != 1)
+    {
+        std::ostringstream err;
+        err << "Could not read from MPL3115A2" << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+    std::vector<uint8_t> data;
+    data.assign(cArray.get(), cArray.get() + size);
+    return data;
+}
+
+
+void MPL3115A2::writeBytes(const std::vector<uint8_t> &data) const
+{
+    std::unique_ptr<uint8_t> cArray(new uint8_t[data.size()]);
+    uint8_t *currentElement = cArray.get();
+    for (uint8_t x : data)
+    {
+        *currentElement = x;
+        ++currentElement;
+    }
+    if (write(m_i2cFile, cArray.get(), data.size()) != 3)
+    {
+        std::ostringstream err;
+        err << "Could not write to MPL3115A2" << strerror(errno);
+        throw std::runtime_error(err.str());
     }
 }

--- a/mpl3115a2.hpp
+++ b/mpl3115a2.hpp
@@ -1,15 +1,21 @@
 #ifndef MPL3115A2_HPP
 #define MPL3115A2_HPP
 
+#include <stdint.h>
 #include <string>
+#include <vector>
 
 
 class MPL3115A2
 {
     public:
         // Attempts to open the i2c connection at the adapterNumber
-        MPL3115A2(unsigned int adapterNumber);
+        MPL3115A2(const unsigned int adapterNumber);
     private:
+        std::vector<uint8_t> readBytes(const uint8_t reg, const unsigned int size) const;
+
+        // Expects the first element in data to be the register to be written to
+        void writeBytes(const std::vector<uint8_t> &data) const;
         std::string m_i2cFilename;
         int m_i2cFile;
 };


### PR DESCRIPTION
Refactored i2c read and write calls to their own functions. Definitely
still naively using the i2c-dev interface. There seems to be a more
ideal way to read and write by using an ioctl call. There are not many
examples online though and the kernel documentation is unclear on how
this should be used.