### PR TITLE
Implement basic functions specific to MPL3115A2

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,17 +1,52 @@
+#include <chrono>
+#include <fstream>
 #include <iostream>
 #include <string>
+#include <thread>
 #include "mpl3115a2.hpp"
 
 
 int main(int argc, char **argv)
 {
-    std::cout << "Hello world!" << std::endl;
-    if (argc != 2)
+    bool logToFile = false;
+    char *filename = nullptr;
+    if (argc < 2)
     {
         std::cerr << "Please give the i2c adapter number (found using i2cdetect -l)" << std::endl;
         return 1;
     }
+    else if (argc == 3)
+    {
+        logToFile = true;
+        filename = argv[2];
+    }
     std::string adapter(argv[1]);
-    MPL3115A2 temp(stoi(adapter));
+    MPL3115A2 mpl3115a2(stoi(adapter));
+
+    if (logToFile)
+    {
+        std::ofstream file(filename);
+        file << "Temperature (C), Altitude (m)" << std::endl;
+        for (;;)
+        {
+            // No idea how fast this will actually poll, we don't really care for this data
+            MPL3115A2DATA data = mpl3115a2.getAltitude();
+            file << data.temperature << "," << data.altitude << std::endl;
+            std::chrono::milliseconds timespan(50);
+            std::this_thread::sleep_for(timespan);
+        }
+    }
+    else
+    {
+        for (;;)
+        {
+            MPL3115A2DATA data = mpl3115a2.getAltitude();
+            std::cout << "Temperature: " << data.temperature << " (C)"<< std::endl;
+            std::cout << "Altitude: " << data.altitude << " (m)"<< std::endl;
+            std::chrono::seconds timespan(1);
+            std::this_thread::sleep_for(timespan);
+        }
+    }
+
     return 0;
 }

--- a/mpl3115a2.cpp
+++ b/mpl3115a2.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -5,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 #include <string.h>
+#include <thread>
 #include <vector>
 
 #include <errno.h>
@@ -23,8 +25,25 @@ constexpr uint8_t STATUS = 0x00;
 constexpr uint8_t DATA_READY = 0x06;
 constexpr uint8_t WHO_AM_I = 0x0C;
 constexpr uint8_t PT_DATA_CFG = 0x13;
+constexpr uint8_t CTRL_REG1 = 0x26;
+constexpr uint8_t PRESSURE_MSB = 0x01;
+constexpr uint8_t PRESSURE_CSB = 0x02;
+constexpr uint8_t PRESSURE_LSB = 0x03;
+constexpr uint8_t TEMPERATURE_MSB = 0x04;
+constexpr uint8_t TEMPERATURE_LSB = 0x05;
+
 // Register defaults
 constexpr uint8_t DEVICE_ID = 0xC4;
+
+// Register masks
+constexpr uint8_t STANDBY_BAR_MASK = 0x01;  // Standby bit of ctrl register 1
+constexpr uint8_t ALTIMETER_MASK = 0x80;  // If bit is set device is measuring altitude otherwise pressure
+constexpr uint8_t PT_DATA_CFG_DREM_MASK = 0x04;
+constexpr uint8_t PT_DATA_CFG_TDEFE_MASK  = 0x01;
+constexpr uint8_t PT_DATA_CFG_PDEFE_MASK  = 0x02;
+constexpr uint8_t STATUS_TDR_MASK = 0x02;
+constexpr uint8_t STATUS_PDR_MASK =  0x04;
+constexpr uint8_t STATUS_PTDR_MASK = 0x08;
 
 
 MPL3115A2::MPL3115A2(const unsigned int adapterNumber)
@@ -75,8 +94,58 @@ MPL3115A2::MPL3115A2(const unsigned int adapterNumber)
     {
         std::cout << "MPL3115A2 confirmed to be on I2C bus represented by "
                   << m_i2cFilename << std::endl;
-        close(m_i2cFile);
     }
+
+    configureDataReadyFlag();
+    configureAltimeterMode();
+}
+
+
+uint8_t MPL3115A2::enterStandbyMode(void) const
+{
+    // Enter standby mode to allow register writing
+    // Return the register data to allow it to be restored to previous state
+    uint8_t controlRegisterData = readByte(CTRL_REG1);
+    writeByte(CTRL_REG1, controlRegisterData & ~STANDBY_BAR_MASK);  // Clear standby bar bit
+    return controlRegisterData;
+}
+
+
+void MPL3115A2::configureAltimeterMode(void)
+{
+    // Clear the standby-bar bit to activate standby mode
+    uint8_t controlRegisterData = enterStandbyMode();
+
+    // Set the mode to altimeter and set the standby-bar bit to deactivate standby mode
+    writeByte(CTRL_REG1, controlRegisterData | ALTIMETER_MASK | STANDBY_BAR_MASK);
+    isAltimeterMode = true;
+    isBarometerMode = false;
+}
+
+
+void MPL3115A2::configureBarometerMode(void)
+{
+    // Clear the standby-bar bit to activate standby mode
+    uint8_t controlRegisterData = enterStandbyMode();
+
+    // Set the mode to barometer and set the standby-bar bit to deactivate standby mode
+    writeByte(CTRL_REG1, (controlRegisterData & ~ALTIMETER_MASK) | STANDBY_BAR_MASK);
+    isAltimeterMode = false;
+    isBarometerMode = true;
+}
+
+
+void MPL3115A2::configureDataReadyFlag(void) const
+{
+    // Clear the standby-bar bit to activate standby mode
+    // Entering standby mode maybe unnecessary to change this register but we'll do it anyways
+    uint8_t controlRegisterData = enterStandbyMode();
+
+    // Configure the sensor data register to raise a status flag when any new data is available
+    writeByte(PT_DATA_CFG, PT_DATA_CFG_DREM_MASK | PT_DATA_CFG_TDEFE_MASK | PT_DATA_CFG_PDEFE_MASK);
+
+    // Set device back to active mode
+    writeByte(CTRL_REG1, controlRegisterData | STANDBY_BAR_MASK);
 }
 
 
@@ -134,4 +203,113 @@ void MPL3115A2::writeByte(uint8_t reg, uint8_t data) const
         err << "Could not perform write" << std::endl << strerror(errno);
         throw std::runtime_error(err.str());
     }
+}
+
+
+MPL3115A2DATA MPL3115A2::getPressure(void)
+{
+    if (!isBarometerMode)
+    {
+        configureBarometerMode();
+    }
+
+    // Poll until there is data available
+    uint8_t status = readByte(STATUS);
+    while (!(status & STATUS_PTDR_MASK))
+    {
+        status = readByte(STATUS);
+        std::chrono::milliseconds timespan(10);
+        std::this_thread::sleep_for(timespan);
+    }
+
+    // Upper two bytes + top two bits in LSB represent the 18 bit unsigned integer portion in Pascals
+    // Bits 5-4 of LSB represent fractional portion
+    uint8_t MSB = readByte(PRESSURE_MSB);
+    uint8_t CSB = readByte(PRESSURE_CSB);
+    uint8_t LSB = readByte(PRESSURE_LSB);
+    double temperature = getTemperature();
+
+    // Get integer portion
+    unsigned int intPortion = MSB;
+    intPortion <<= 8;
+    intPortion |= CSB;
+    intPortion <<= 2;
+    intPortion |= (LSB >> 6);
+
+    // Isolate fractional portion
+    uint8_t fractionalPortion = LSB;
+    fractionalPortion <<= 2;
+    fractionalPortion >>= 6;
+
+    // Calculate pressure
+    double fraction = LSB / 4.0;
+    double pressure = intPortion + fraction;
+
+    MPL3115A2DATA data;
+    data.pressure = pressure;
+    data.temperature = temperature;
+    return data;
+}
+
+
+MPL3115A2DATA MPL3115A2::getAltitude(void)
+{
+    if (!isAltimeterMode)
+    {
+        configureAltimeterMode();
+    }
+    uint8_t status = readByte(STATUS);
+    while (!(status & STATUS_PTDR_MASK))
+    {
+        status = readByte(STATUS);
+        std::chrono::milliseconds timespan(10);
+        std::this_thread::sleep_for(timespan);
+    }
+
+    // MSB and CSB represent signed int portion in meters, bits 7-4 represent fractional portion
+    uint8_t MSB = readByte(PRESSURE_MSB);
+    uint8_t CSB = readByte(PRESSURE_CSB);
+    uint8_t LSB = readByte(PRESSURE_LSB);
+    double temperature = getTemperature();
+
+    // Get signed int portion
+    int16_t intPortion = MSB;
+    intPortion <<= 8;
+    intPortion |= CSB;
+
+    // Get fraction
+    uint8_t temp = LSB;
+    temp >>= 4;
+    double fraction = temp / 16.0;
+    if (intPortion < 0)
+    {
+      fraction *= -1;
+    }
+
+    double altitude = intPortion + fraction;
+
+    MPL3115A2DATA data;
+    data.altitude = altitude;
+    data.temperature = temperature;
+    return data;
+}
+
+
+double MPL3115A2::getTemperature(void)
+{
+  // MSB is integer portion, LSB 7-4 is fractional, in Celcius
+  int8_t intPortion = readByte(TEMPERATURE_MSB);
+  uint8_t fractionalPortion = readByte(TEMPERATURE_LSB);
+
+  // Get fraction
+  uint8_t temp = fractionalPortion;
+  temp >>= 4;
+  double fraction = temp / 16.0;
+  if (intPortion < 0)
+  {
+      fraction *= -1;
+  }
+
+  double temperature = intPortion + fraction;
+  return temperature;
 }

--- a/mpl3115a2.hpp
+++ b/mpl3115a2.hpp
@@ -6,16 +6,38 @@
 #include <vector>
 
 
+struct MPL3115A2DATA
+{
+    public:
+        double pressure;
+        double altitude;
+        double temperature;
+};
+
+
 class MPL3115A2
 {
     public:
+
         // Attempts to open the i2c connection at the adapterNumber
         MPL3115A2(const unsigned int adapterNumber);
+
+        MPL3115A2DATA getPressure(void);
+        MPL3115A2DATA getAltitude(void);
+
     private:
+        double getTemperature(void);
+        uint8_t enterStandbyMode(void) const;
+        void configureDataReadyFlag(void) const;
+        void configureAltimeterMode(void);
+        void configureBarometerMode(void);
         uint8_t readByte(uint8_t reg) const;
         void writeByte(uint8_t reg, uint8_t data) const;
+
         std::string m_i2cFilename;
         int m_i2cFile;
+        bool isAltimeterMode;
+        bool isBarometerMode;
 };
 
 #endif


### PR DESCRIPTION
Finished writing the getter and configuration functions. These functions read
either pressure & temperature, or altitude & temperature, depending on
the function used.

Two more things NEED to be done for the MPL3115A2:
- Add a readBytes function. This would allow the data to be read in one
  i2c transaction (opposed to multiple readByte calls) and maybe the cause of our innaccuracies.
- Add and perform calibration for the device to correct for any errors
  in measurements.

Another thing that SHOULD be done:
- Factor out the i2c functions into their own class and inherit from
  them to ease the development with other i2c chips.