### PR TITLE
Refactor to have generic i2c connection class

### DIFF
--- a/i2c-abstraction.cpp
+++ b/i2c-abstraction.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <stdint.h>
+#include <sstream>
+#include <string>
+#include <string.h>
+#include <vector>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "i2c-abstraction.hpp"
+
+
+I2cAbstraction::I2cAbstraction(const unsigned int adapterNumber, const uint8_t deviceAddress)
+{
+    m_deviceAddress = deviceAddress;
+    std::ostringstream oss;
+    oss << "/dev/i2c-" << adapterNumber;
+    m_i2cFilename = oss.str();
+    m_i2cFile = open(m_i2cFilename.c_str(), O_RDWR);
+    if (m_i2cFile < 0)
+    {
+        std::ostringstream err;
+        err << "Could not open " << m_i2cFilename << std::endl << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+    if (ioctl(m_i2cFile, I2C_SLAVE, m_deviceAddress) < 0)
+    {
+        std::ostringstream err;
+        err << "Could not set slave address\n" << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+    unsigned long funcs = 0;
+    if (ioctl(m_i2cFile, I2C_FUNCS, &funcs) < 0)
+    {
+        std::ostringstream err;
+        err << "Could not get available functionality from the i2c adapter"
+            << std::endl << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+    if (!(funcs & I2C_FUNC_I2C))
+    {
+        std::ostringstream err;
+        err << "The adapter does not support a mixed read write transaction"
+            << std::endl << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+}
+
+
+std::vector<uint8_t> I2cAbstraction::readBytes(uint8_t reg, unsigned int size) const
+{
+    struct i2c_rdwr_ioctl_data packagedMessages;
+    struct i2c_msg messages[2];
+
+    // This message is responsible for telling the device which register we want data from
+    messages[0].addr = m_deviceAddress;
+    messages[0].flags = 0;
+    messages[0].len = sizeof(reg);
+    messages[0].buf = &reg;
+
+    // This message contains the data from the register
+    std::unique_ptr<uint8_t[]> data(new uint8_t[size]);
+    messages[1].addr  = m_deviceAddress;
+    messages[1].flags = I2C_M_RD;
+    messages[1].len   = size;
+    messages[1].buf   = data.get();
+
+    // Ask for the transaction to take place
+    packagedMessages.msgs = messages;
+    packagedMessages.nmsgs = 2;
+    if(ioctl(m_i2cFile, I2C_RDWR, &packagedMessages) < 0)
+    {
+        std::ostringstream err;
+        err << "Could not perform read" << std::endl << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+    return std::vector<uint8_t>(data.get(), data.get() + size);
+}
+
+
+void I2cAbstraction::writeByte(uint8_t reg, uint8_t data) const
+{
+    struct i2c_rdwr_ioctl_data packagedMessages;
+    struct i2c_msg message;
+
+    // This message contains the register to write to as well as the data to write
+    uint8_t out[2];
+    out[0] = reg;
+    out[1] = data;
+    message.addr = m_deviceAddress;
+    message.flags = 0;
+    message.len = sizeof(out);
+    message.buf = out;
+
+    packagedMessages.msgs = &message;
+    packagedMessages.nmsgs = 1;
+
+    if(ioctl(m_i2cFile, I2C_RDWR, &packagedMessages) < 0)
+    {
+        std::ostringstream err;
+        err << "Could not perform write" << std::endl << strerror(errno);
+        throw std::runtime_error(err.str());
+    }
+}

--- a/i2c-abstraction.hpp
+++ b/i2c-abstraction.hpp
@@ -1,0 +1,25 @@
+#ifndef I2C_ABSTRACTION_HPP
+#define I2C_ABSTRACTION_HPP
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+
+// This class is an abstraction for a i2c connection to a single device.
+// The current implementation is based on linux
+// readBytes provides a function to read sequential registers from a device.
+// writeByte provides a way to write to a register.
+class I2cAbstraction
+{
+    public:
+        I2cAbstraction(const unsigned int adapterNumber, const uint8_t deviceAddress);
+        std::vector<uint8_t> readBytes(uint8_t reg, unsigned int size) const;
+        void writeByte(uint8_t reg, uint8_t data) const;
+    private:
+        std::string m_i2cFilename;
+        int m_i2cFile;
+        uint8_t m_deviceAddress;
+};
+
+#endif

--- a/makefile
+++ b/makefile
@@ -4,8 +4,8 @@ GDB=-g -O0
 CXXFLAGS=-I. -Wall -Wextra -std=c++11 $(GDB) $(ADDRESSSANITIZER)
 LIBS=
 
-DEPS = mpl3115a2.hpp
-I2COBJS = main.o mpl3115a2.o
+DEPS = mpl3115a2.hpp i2c-abstraction.hpp
+I2COBJS = main.o mpl3115a2.o i2c-abstraction.o
 OBJS = $(I2COBJS)
 
 all: i2c

--- a/mpl3115a2.hpp
+++ b/mpl3115a2.hpp
@@ -1,11 +1,15 @@
 #ifndef MPL3115A2_HPP
 #define MPL3115A2_HPP
 
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
 
+#include "i2c-abstraction.hpp"
 
+
+// This struct represents the data available from the device.
 struct MPL3115A2DATA
 {
     public:
@@ -15,13 +19,14 @@ struct MPL3115A2DATA
 };
 
 
+// This class represents the MPL3115A2.
+// Using getPressure and getAltitude will return a data struct with
+// temperature and pressure/altitude data, depending on the function used.
 class MPL3115A2
 {
     public:
-
         // Attempts to open the i2c connection at the adapterNumber
         MPL3115A2(const unsigned int adapterNumber);
-
         MPL3115A2DATA getPressure(void);
         MPL3115A2DATA getAltitude(void);
 
@@ -31,13 +36,8 @@ class MPL3115A2
         void configureDataReadyFlag(void) const;
         void configureAltimeterMode(void);
         void configureBarometerMode(void);
-        std::vector<uint8_t> readBytes(uint8_t reg, unsigned int size) const;
         std::vector<uint8_t> getData(void) const;
-        void writeByte(uint8_t reg, uint8_t data) const;
-
-
-        std::string m_i2cFilename;
-        int m_i2cFile;
+        std::unique_ptr<I2cAbstraction> m_connection;
         bool isAltimeterMode;
         bool isBarometerMode;
 };


### PR DESCRIPTION
Refactored the code to provide a generic i2c connection to a single
device. This way we can share the functionality between other i2c
devices down the road. I could see an argument for defining a pure
virtual interface and then a linux implementation from that, but that
can wait.